### PR TITLE
Upgrade to arrow2 v0.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf6ccdb167abbf410dcb915cabd428929d7f6a04980b54a11f26a39f1c7f7107"
 dependencies = [
  "cfg-if",
- "const-random",
  "getrandom",
  "once_cell",
  "version_check",
@@ -75,9 +74,9 @@ dependencies = [
 
 [[package]]
 name = "arrow2"
-version = "0.15.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b843531e0a9d8dac44b0aa6adc926b2d970e8a627fe2105cd0498d5f93a6e97f"
+checksum = "15ae0428d69ab31d7b2adad22a752d6f11fef2e901d2262d0cad4f5cb08b7093"
 dependencies = [
  "ahash",
  "arrow-format",
@@ -159,9 +158,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "bitflags"
@@ -308,28 +307,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-random"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368a7a772ead6ce7e1de82bfb04c485f3db8ec744f72925af5735e29a22cc18e"
-dependencies = [
- "const-random-macro",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "const-random-macro"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d7d6ab3c3a2282db210df5f02c4dab6e0a7057af0fb7ebd4070f30fe05c0ddb"
-dependencies = [
- "getrandom",
- "once_cell",
- "proc-macro-hack",
- "tiny-keccak",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,12 +399,6 @@ checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "crunchy"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "dyn-clone"
@@ -1051,12 +1022,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1299,15 +1264,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,12 @@ geos = { version = "8", features = ["v3_8_0", "geo"], optional = true }
 thiserror = "1"
 anyhow = "1"
 geozero = { version = "0.9.4", features = ["with-wkb"] }
-arrow2 = { version = "0.15" }
+arrow2 = { version = "0.17" }
 # TODO: properly feature gate this
 rstar = { version = "0.9.3" }
 
 [dev-dependencies]
-arrow2 = { version = "0.15", features = [
+arrow2 = { version = "0.17", features = [
   "io_parquet",
   "io_parquet_compression",
 ] }

--- a/src/binary/array.rs
+++ b/src/binary/array.rs
@@ -70,27 +70,24 @@ impl<'a> GeometryArrayTrait<'a> for WKBArray {
     ///
     /// let array = PrimitiveArray::from_vec(vec![1, 2, 3]);
     /// assert_eq!(format!("{:?}", array), "Int32[1, 2, 3]");
-    /// let sliced = array.slice(1, 1);
-    /// assert_eq!(format!("{:?}", sliced), "Int32[2]");
-    /// // note: `sliced` and `array` share the same memory region.
+    /// array.slice(1, 1);
+    /// assert_eq!(format!("{:?}", array), "Int32[2]");
     /// ```
     /// # Panic
     /// This function panics iff `offset + length > self.len()`.
     #[inline]
-    #[must_use]
-    fn slice(&self, offset: usize, length: usize) -> Self {
-        WKBArray(self.0.slice(offset, length))
+    fn slice(&mut self, offset: usize, length: usize) {
+        self.0.slice(offset, length);
     }
 
-    /// Returns a clone of this [`PrimitiveArray`] sliced by an offset and length.
+    /// Slices this [`PrimitiveArray`] by an offset and length.
     /// # Implementation
-    /// This operation is `O(1)` as it amounts to increase two ref counts.
+    /// This operation is `O(1)`.
     /// # Safety
     /// The caller must ensure that `offset + length <= self.len()`.
     #[inline]
-    #[must_use]
-    unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Self {
-        WKBArray(self.0.slice_unchecked(offset, length))
+    unsafe fn slice_unchecked(&mut self, offset: usize, length: usize) {
+        self.0.slice_unchecked(offset, length);
     }
 
     fn to_boxed(&self) -> Box<Self> {

--- a/src/enum_.rs
+++ b/src/enum_.rs
@@ -136,7 +136,6 @@ impl<'a> GeometryArrayTrait<'a> for GeometryArray {
     fn rstar_tree(&'a self) -> rstar::RTree<Self::Scalar> {
         let mut tree = RTree::new();
         (0..self.len())
-            .into_iter()
             .filter_map(|geom_idx| self.get(geom_idx))
             .for_each(|geom| tree.insert(geom));
         tree
@@ -171,53 +170,40 @@ impl<'a> GeometryArrayTrait<'a> for GeometryArray {
         }
     }
 
-    /// Slices the [`GeometryArray`], returning a new [`GeometryArray`].
+    /// Slices the [`GeometryArray`] in plave.
     /// # Implementation
     /// This operation is `O(1)` over `len`, as it amounts to increase two ref counts
     /// and moving the struct to the heap.
     /// # Panic
     /// This function panics iff `offset + length > self.len()`.
-    fn slice(&self, offset: usize, length: usize) -> GeometryArray {
+    fn slice(&mut self, offset: usize, length: usize) {
         match self {
-            GeometryArray::Point(arr) => GeometryArray::Point(arr.slice(offset, length)),
-            GeometryArray::LineString(arr) => GeometryArray::LineString(arr.slice(offset, length)),
-            GeometryArray::Polygon(arr) => GeometryArray::Polygon(arr.slice(offset, length)),
-            GeometryArray::MultiPoint(arr) => GeometryArray::MultiPoint(arr.slice(offset, length)),
-            GeometryArray::MultiLineString(arr) => {
-                GeometryArray::MultiLineString(arr.slice(offset, length))
-            }
-            GeometryArray::MultiPolygon(arr) => {
-                GeometryArray::MultiPolygon(arr.slice(offset, length))
-            }
-            GeometryArray::WKB(arr) => GeometryArray::WKB(arr.slice(offset, length)),
-        }
+            GeometryArray::Point(arr) => arr.slice(offset, length),
+            GeometryArray::LineString(arr) => arr.slice(offset, length),
+            GeometryArray::Polygon(arr) => arr.slice(offset, length),
+            GeometryArray::MultiPoint(arr) => arr.slice(offset, length),
+            GeometryArray::MultiLineString(arr) => arr.slice(offset, length),
+            GeometryArray::MultiPolygon(arr) => arr.slice(offset, length),
+            GeometryArray::WKB(arr) => arr.slice(offset, length),
+        };
     }
 
-    /// Slices the [`GeometryArray`], returning a new [`GeometryArray`].
+    /// Slices the [`GeometryArray`] in place.
     /// # Implementation
-    /// This operation is `O(1)` over `len`, as it amounts to increase two ref counts
-    /// and moving the struct to the heap.
+    /// This operation is `O(1)` over `len`.
     /// # Safety
     /// The caller must ensure that `offset + length <= self.len()`
-    unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> GeometryArray {
+    unsafe fn slice_unchecked(&mut self, offset: usize, length: usize) {
         match self {
-            GeometryArray::Point(arr) => GeometryArray::Point(arr.slice_unchecked(offset, length)),
-            GeometryArray::LineString(arr) => {
-                GeometryArray::LineString(arr.slice_unchecked(offset, length))
+            GeometryArray::Point(arr) => arr.slice_unchecked(offset, length),
+            GeometryArray::LineString(arr) => arr.slice_unchecked(offset, length),
+            GeometryArray::Polygon(arr) => arr.slice_unchecked(offset, length),
+            GeometryArray::MultiPoint(arr) => arr.slice_unchecked(offset, length),
+            GeometryArray::MultiLineString(arr) => arr.slice_unchecked(offset, length),
+            GeometryArray::MultiPolygon(arr) => arr.slice_unchecked(offset, length),
+            GeometryArray::WKB(arr) => {
+                arr.slice_unchecked(offset, length);
             }
-            GeometryArray::Polygon(arr) => {
-                GeometryArray::Polygon(arr.slice_unchecked(offset, length))
-            }
-            GeometryArray::MultiPoint(arr) => {
-                GeometryArray::MultiPoint(arr.slice_unchecked(offset, length))
-            }
-            GeometryArray::MultiLineString(arr) => {
-                GeometryArray::MultiLineString(arr.slice_unchecked(offset, length))
-            }
-            GeometryArray::MultiPolygon(arr) => {
-                GeometryArray::MultiPolygon(arr.slice_unchecked(offset, length))
-            }
-            GeometryArray::WKB(arr) => GeometryArray::WKB(arr.slice_unchecked(offset, length)),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,4 +22,5 @@ pub mod multipoint;
 pub mod multipolygon;
 pub mod point;
 pub mod polygon;
+mod slice;
 pub mod trait_;

--- a/src/linestring/array.rs
+++ b/src/linestring/array.rs
@@ -1,4 +1,5 @@
 use crate::error::GeoArrowError;
+use crate::slice::slice_validity_unchecked;
 use crate::{GeometryArrayTrait, MultiPointArray};
 use arrow2::array::{Array, ListArray, PrimitiveArray, StructArray};
 use arrow2::bitmap::utils::{BitmapIter, ZipValidity};
@@ -35,7 +36,7 @@ pub(super) fn check(
     geom_offsets: &OffsetsBuffer<i64>,
 ) -> Result<(), GeoArrowError> {
     // TODO: check geom offsets?
-    if validity_len.map_or(false, |len| len != geom_offsets.len()) {
+    if validity_len.map_or(false, |len| len != geom_offsets.len_proxy()) {
         return Err(GeoArrowError::General(
             "validity mask length must match the number of values".to_string(),
         ));
@@ -139,7 +140,7 @@ impl<'a> GeometryArrayTrait<'a> for LineStringArray {
     /// Returns the number of geometries in this array
     #[inline]
     fn len(&self) -> usize {
-        self.geom_offsets.len()
+        self.geom_offsets.len_proxy()
     }
 
     /// Returns the optional validity.
@@ -148,56 +149,38 @@ impl<'a> GeometryArrayTrait<'a> for LineStringArray {
         self.validity.as_ref()
     }
 
-    /// Returns a clone of this [`PrimitiveArray`] sliced by an offset and length.
+    /// Slices this [`PrimitiveArray`] in place.
     /// # Implementation
-    /// This operation is `O(1)` as it amounts to increase two ref counts.
+    /// This operation is `O(1)`.
     /// # Examples
     /// ```
     /// use arrow2::array::PrimitiveArray;
     ///
     /// let array = PrimitiveArray::from_vec(vec![1, 2, 3]);
     /// assert_eq!(format!("{:?}", array), "Int32[1, 2, 3]");
-    /// let sliced = array.slice(1, 1);
-    /// assert_eq!(format!("{:?}", sliced), "Int32[2]");
-    /// // note: `sliced` and `array` share the same memory region.
+    /// array.slice(1, 1);
+    /// assert_eq!(format!("{:?}", array), "Int32[2]");
     /// ```
     /// # Panic
     /// This function panics iff `offset + length > self.len()`.
     #[inline]
-    #[must_use]
-    fn slice(&self, offset: usize, length: usize) -> Self {
+    fn slice(&mut self, offset: usize, length: usize) {
         assert!(
             offset + length <= self.len(),
             "offset + length may not exceed length of array"
         );
-        unsafe { self.slice_unchecked(offset, length) }
+        unsafe { self.slice_unchecked(offset, length) };
     }
 
-    /// Returns a clone of this [`PrimitiveArray`] sliced by an offset and length.
+    /// Slices this [`PrimitiveArray`] in place.
     /// # Implementation
-    /// This operation is `O(1)` as it amounts to increase two ref counts.
+    /// This operation is `O(1)`.
     /// # Safety
     /// The caller must ensure that `offset + length <= self.len()`.
     #[inline]
-    #[must_use]
-    unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Self {
-        let validity = self
-            .validity
-            .clone()
-            .map(|bitmap| bitmap.slice_unchecked(offset, length))
-            .and_then(|bitmap| (bitmap.unset_bits() > 0).then_some(bitmap));
-
-        let geom_offsets = self
-            .geom_offsets
-            .clone()
-            .slice_unchecked(offset, length + 1);
-
-        Self {
-            x: self.x.clone(),
-            y: self.y.clone(),
-            geom_offsets,
-            validity,
-        }
+    unsafe fn slice_unchecked(&mut self, offset: usize, length: usize) {
+        slice_validity_unchecked(&mut self.validity, offset, length);
+        self.geom_offsets.slice_unchecked(offset, length + 1);
     }
 
     fn to_boxed(&self) -> Box<Self> {
@@ -403,9 +386,9 @@ mod test {
 
     #[test]
     fn slice() {
-        let arr: LineStringArray = vec![ls0(), ls1()].into();
-        let sliced = arr.slice(1, 1);
-        assert_eq!(sliced.len(), 1);
-        assert_eq!(sliced.get_as_geo(0), Some(ls1()));
+        let mut arr: LineStringArray = vec![ls0(), ls1()].into();
+        arr.slice(1, 1);
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr.get_as_geo(0), Some(ls1()));
     }
 }

--- a/src/multilinestring/array.rs
+++ b/src/multilinestring/array.rs
@@ -1,4 +1,5 @@
 use crate::error::GeoArrowError;
+use crate::slice::slice_validity_unchecked;
 use crate::{GeometryArrayTrait, PolygonArray};
 use arrow2::array::{Array, ListArray, PrimitiveArray, StructArray};
 use arrow2::bitmap::utils::{BitmapIter, ZipValidity};
@@ -37,7 +38,7 @@ pub(super) fn check(
     geom_offsets: &OffsetsBuffer<i64>,
 ) -> Result<(), GeoArrowError> {
     // TODO: check geom offsets and ring_offsets?
-    if validity_len.map_or(false, |len| len != geom_offsets.len()) {
+    if validity_len.map_or(false, |len| len != geom_offsets.len_proxy()) {
         return Err(GeoArrowError::General(
             "validity mask length must match the number of values".to_string(),
         ));
@@ -123,7 +124,7 @@ impl<'a> GeometryArrayTrait<'a> for MultiLineStringArray {
     /// Returns the number of geometries in this array
     #[inline]
     fn len(&self) -> usize {
-        self.geom_offsets.len()
+        self.geom_offsets.len_proxy()
     }
 
     /// Returns the optional validity.
@@ -132,57 +133,38 @@ impl<'a> GeometryArrayTrait<'a> for MultiLineStringArray {
         self.validity.as_ref()
     }
 
-    /// Returns a clone of this [`PrimitiveArray`] sliced by an offset and length.
+    /// Slices this [`PrimitiveArray`] in place.
     /// # Implementation
-    /// This operation is `O(1)` as it amounts to increase two ref counts.
+    /// This operation is `O(1)`.
     /// # Examples
     /// ```
     /// use arrow2::array::PrimitiveArray;
     ///
     /// let array = PrimitiveArray::from_vec(vec![1, 2, 3]);
     /// assert_eq!(format!("{:?}", array), "Int32[1, 2, 3]");
-    /// let sliced = array.slice(1, 1);
-    /// assert_eq!(format!("{:?}", sliced), "Int32[2]");
-    /// // note: `sliced` and `array` share the same memory region.
+    /// array.slice(1, 1);
+    /// assert_eq!(format!("{:?}", array), "Int32[2]");
     /// ```
     /// # Panic
     /// This function panics iff `offset + length > self.len()`.
     #[inline]
-    #[must_use]
-    fn slice(&self, offset: usize, length: usize) -> Self {
+    fn slice(&mut self, offset: usize, length: usize) {
         assert!(
             offset + length <= self.len(),
             "offset + length may not exceed length of array"
         );
-        unsafe { self.slice_unchecked(offset, length) }
+        unsafe { self.slice_unchecked(offset, length) };
     }
 
-    /// Returns a clone of this [`PrimitiveArray`] sliced by an offset and length.
+    /// Slices this [`PrimitiveArray`] in place.
     /// # Implementation
-    /// This operation is `O(1)` as it amounts to increase two ref counts.
+    /// This operation is `O(1)`.
     /// # Safety
     /// The caller must ensure that `offset + length <= self.len()`.
     #[inline]
-    #[must_use]
-    unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Self {
-        let validity = self
-            .validity
-            .clone()
-            .map(|bitmap| bitmap.slice_unchecked(offset, length))
-            .and_then(|bitmap| (bitmap.unset_bits() > 0).then_some(bitmap));
-
-        let geom_offsets = self
-            .geom_offsets
-            .clone()
-            .slice_unchecked(offset, length + 1);
-
-        Self {
-            x: self.x.clone(),
-            y: self.y.clone(),
-            geom_offsets,
-            ring_offsets: self.ring_offsets.clone(),
-            validity,
-        }
+    unsafe fn slice_unchecked(&mut self, offset: usize, length: usize) {
+        slice_validity_unchecked(&mut self.validity, offset, length);
+        self.geom_offsets.slice_unchecked(offset, length + 1);
     }
 
     fn to_boxed(&self) -> Box<Self> {
@@ -417,9 +399,9 @@ mod test {
 
     #[test]
     fn slice() {
-        let arr: MultiLineStringArray = vec![ml0(), ml1()].into();
-        let sliced = arr.slice(1, 1);
-        assert_eq!(sliced.len(), 1);
-        assert_eq!(sliced.get_as_geo(0), Some(ml1()));
+        let mut arr: MultiLineStringArray = vec![ml0(), ml1()].into();
+        arr.slice(1, 1);
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr.get_as_geo(0), Some(ml1()));
     }
 }

--- a/src/multipoint/array.rs
+++ b/src/multipoint/array.rs
@@ -1,5 +1,6 @@
 use super::MutableMultiPointArray;
 use crate::error::GeoArrowError;
+use crate::slice::slice_validity_unchecked;
 use crate::{GeometryArrayTrait, LineStringArray};
 use arrow2::array::{Array, ListArray, PrimitiveArray, StructArray};
 use arrow2::bitmap::utils::{BitmapIter, ZipValidity};
@@ -33,7 +34,7 @@ pub(super) fn check(
     geom_offsets: &OffsetsBuffer<i64>,
 ) -> Result<(), GeoArrowError> {
     // TODO: check geom offsets?
-    if validity_len.map_or(false, |len| len != geom_offsets.len()) {
+    if validity_len.map_or(false, |len| len != geom_offsets.len_proxy()) {
         return Err(GeoArrowError::General(
             "validity mask length must match the number of values".to_string(),
         ));
@@ -113,7 +114,7 @@ impl<'a> GeometryArrayTrait<'a> for MultiPointArray {
     /// Returns the number of geometries in this array
     #[inline]
     fn len(&self) -> usize {
-        self.geom_offsets.len()
+        self.geom_offsets.len_proxy()
     }
 
     /// Returns the optional validity.
@@ -122,56 +123,38 @@ impl<'a> GeometryArrayTrait<'a> for MultiPointArray {
         self.validity.as_ref()
     }
 
-    /// Returns a clone of this [`PrimitiveArray`] sliced by an offset and length.
+    /// Slices this [`PrimitiveArray`] in place.
     /// # Implementation
-    /// This operation is `O(1)` as it amounts to increase two ref counts.
+    /// This operation is `O(1)`.
     /// # Examples
     /// ```
     /// use arrow2::array::PrimitiveArray;
     ///
     /// let array = PrimitiveArray::from_vec(vec![1, 2, 3]);
     /// assert_eq!(format!("{:?}", array), "Int32[1, 2, 3]");
-    /// let sliced = array.slice(1, 1);
-    /// assert_eq!(format!("{:?}", sliced), "Int32[2]");
-    /// // note: `sliced` and `array` share the same memory region.
+    /// array.slice(1, 1);
+    /// assert_eq!(format!("{:?}", array), "Int32[2]");
     /// ```
     /// # Panic
     /// This function panics iff `offset + length > self.len()`.
     #[inline]
-    #[must_use]
-    fn slice(&self, offset: usize, length: usize) -> Self {
+    fn slice(&mut self, offset: usize, length: usize) {
         assert!(
             offset + length <= self.len(),
             "offset + length may not exceed length of array"
         );
-        unsafe { self.slice_unchecked(offset, length) }
+        unsafe { self.slice_unchecked(offset, length) };
     }
 
-    /// Returns a clone of this [`PrimitiveArray`] sliced by an offset and length.
+    /// Slices this [`PrimitiveArray`] in place.
     /// # Implementation
-    /// This operation is `O(1)` as it amounts to increase two ref counts.
+    /// This operation is `O(1)`.
     /// # Safety
     /// The caller must ensure that `offset + length <= self.len()`.
     #[inline]
-    #[must_use]
-    unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Self {
-        let validity = self
-            .validity
-            .clone()
-            .map(|bitmap| bitmap.slice_unchecked(offset, length))
-            .and_then(|bitmap| (bitmap.unset_bits() > 0).then_some(bitmap));
-
-        let geom_offsets = self
-            .geom_offsets
-            .clone()
-            .slice_unchecked(offset, length + 1);
-
-        Self {
-            x: self.x.clone(),
-            y: self.y.clone(),
-            geom_offsets,
-            validity,
-        }
+    unsafe fn slice_unchecked(&mut self, offset: usize, length: usize) {
+        slice_validity_unchecked(&mut self.validity, offset, length);
+        self.geom_offsets.slice_unchecked(offset, length + 1);
     }
 
     fn to_boxed(&self) -> Box<Self> {
@@ -370,9 +353,9 @@ mod test {
 
     #[test]
     fn slice() {
-        let arr: MultiPointArray = vec![mp0(), mp1()].into();
-        let sliced = arr.slice(1, 1);
-        assert_eq!(sliced.len(), 1);
-        assert_eq!(sliced.get_as_geo(0), Some(mp1()));
+        let mut arr: MultiPointArray = vec![mp0(), mp1()].into();
+        arr.slice(1, 1);
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr.get_as_geo(0), Some(mp1()));
     }
 }

--- a/src/multipolygon/array.rs
+++ b/src/multipolygon/array.rs
@@ -1,4 +1,5 @@
 use crate::error::GeoArrowError;
+use crate::slice::slice_validity_unchecked;
 use crate::GeometryArrayTrait;
 use arrow2::array::{Array, ListArray, PrimitiveArray, StructArray};
 use arrow2::bitmap::utils::{BitmapIter, ZipValidity};
@@ -41,7 +42,7 @@ pub(super) fn check(
     geom_offsets: &OffsetsBuffer<i64>,
 ) -> Result<(), GeoArrowError> {
     // TODO: check geom offsets and ring_offsets?
-    if validity_len.map_or(false, |len| len != geom_offsets.len()) {
+    if validity_len.map_or(false, |len| len != geom_offsets.len_proxy()) {
         return Err(GeoArrowError::General(
             "validity mask length must match the number of values".to_string(),
         ));
@@ -184,7 +185,7 @@ impl<'a> GeometryArrayTrait<'a> for MultiPolygonArray {
     /// Returns the number of geometries in this array
     #[inline]
     fn len(&self) -> usize {
-        self.geom_offsets.len()
+        self.geom_offsets.len_proxy()
     }
 
     /// Returns the optional validity.
@@ -193,58 +194,38 @@ impl<'a> GeometryArrayTrait<'a> for MultiPolygonArray {
         self.validity.as_ref()
     }
 
-    /// Returns a clone of this [`PrimitiveArray`] sliced by an offset and length.
+    /// Slices this [`PrimitiveArray`] in place.
     /// # Implementation
-    /// This operation is `O(1)` as it amounts to increase two ref counts.
+    /// This operation is `O(1)`.
     /// # Examples
     /// ```
     /// use arrow2::array::PrimitiveArray;
     ///
     /// let array = PrimitiveArray::from_vec(vec![1, 2, 3]);
     /// assert_eq!(format!("{:?}", array), "Int32[1, 2, 3]");
-    /// let sliced = array.slice(1, 1);
-    /// assert_eq!(format!("{:?}", sliced), "Int32[2]");
-    /// // note: `sliced` and `array` share the same memory region.
+    /// array.slice(1, 1);
+    /// assert_eq!(format!("{:?}", array), "Int32[2]");
     /// ```
     /// # Panic
     /// This function panics iff `offset + length > self.len()`.
     #[inline]
-    #[must_use]
-    fn slice(&self, offset: usize, length: usize) -> Self {
+    fn slice(&mut self, offset: usize, length: usize) {
         assert!(
             offset + length <= self.len(),
             "offset + length may not exceed length of array"
         );
-        unsafe { self.slice_unchecked(offset, length) }
+        unsafe { self.slice_unchecked(offset, length) };
     }
 
-    /// Returns a clone of this [`PrimitiveArray`] sliced by an offset and length.
+    /// Slices this [`PrimitiveArray`] in place.
     /// # Implementation
-    /// This operation is `O(1)` as it amounts to increase two ref counts.
+    /// This operation is `O(1)`.
     /// # Safety
     /// The caller must ensure that `offset + length <= self.len()`.
     #[inline]
-    #[must_use]
-    unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Self {
-        let validity = self
-            .validity
-            .clone()
-            .map(|bitmap| bitmap.slice_unchecked(offset, length))
-            .and_then(|bitmap| (bitmap.unset_bits() > 0).then_some(bitmap));
-
-        let geom_offsets = self
-            .geom_offsets
-            .clone()
-            .slice_unchecked(offset, length + 1);
-
-        Self {
-            x: self.x.clone(),
-            y: self.y.clone(),
-            geom_offsets,
-            polygon_offsets: self.polygon_offsets.clone(),
-            ring_offsets: self.ring_offsets.clone(),
-            validity,
-        }
+    unsafe fn slice_unchecked(&mut self, offset: usize, length: usize) {
+        slice_validity_unchecked(&mut self.validity, offset, length);
+        self.geom_offsets.slice_unchecked(offset, length + 1);
     }
 
     fn to_boxed(&self) -> Box<Self> {
@@ -500,10 +481,10 @@ mod test {
 
     #[test]
     fn slice() {
-        let arr: MultiPolygonArray = vec![mp0(), mp1()].into();
-        let sliced = arr.slice(1, 1);
-        assert_eq!(sliced.len(), 1);
-        assert_eq!(sliced.get_as_geo(0), Some(mp1()));
+        let mut arr: MultiPolygonArray = vec![mp0(), mp1()].into();
+        arr.slice(1, 1);
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr.get_as_geo(0), Some(mp1()));
     }
 
     /// This data is taken from the first 9 rows of a new zealand building polygons file found at

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -1,0 +1,20 @@
+use arrow2::bitmap::Bitmap;
+
+#[inline]
+pub(crate) unsafe fn slice_validity_unchecked(
+    validity: &mut Option<Bitmap>,
+    offset: usize,
+    length: usize,
+) {
+    let all_bits_set = validity
+        .as_mut()
+        .map(|bitmap| {
+            bitmap.slice_unchecked(offset, length);
+            bitmap.unset_bits() == 0
+        })
+        .unwrap_or(false);
+
+    if all_bits_set {
+        *validity = None
+    }
+}

--- a/src/trait_.rs
+++ b/src/trait_.rs
@@ -84,21 +84,20 @@ pub trait GeometryArrayTrait<'a> {
         !self.is_null(i)
     }
 
-    /// Slices the array, returning a new geometry array of the same type.
+    /// Slices the array in place
     /// # Implementation
     /// This operation is `O(1)` over `len`, as it amounts to increase two ref counts
     /// and moving the struct to the heap.
     /// # Panic
     /// This function panics iff `offset + length > self.len()`.
-    fn slice(&self, offset: usize, length: usize) -> Self;
+    fn slice(&mut self, offset: usize, length: usize);
 
-    /// Slices the array, returning a new geometry array of the same type.
+    /// Slices the array in place.
     /// # Implementation
-    /// This operation is `O(1)` over `len`, as it amounts to increase two ref counts
-    /// and moving the struct to the heap.
+    /// This operation is `O(1)` over `len` .
     /// # Safety
     /// The caller must ensure that `offset + length <= self.len()`
-    unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Self;
+    unsafe fn slice_unchecked(&mut self, offset: usize, length: usize);
 
     // /// Clones this [`GeometryArray`] with a new new assigned bitmap.
     // /// # Panic


### PR DESCRIPTION
Hi Kyle,

I used this crate but required a more current version of `arrow2`, so I did the migration and decided a PR may be helpful.

The main changes are related to the `slice` method now modifying the array itself instead of returning a cloned array (https://github.com/jorgecarleitao/arrow2/pull/1396), and the newly introduced `Offset::len_proxy` method (https://github.com/jorgecarleitao/arrow2/pull/1330).

Please review carefully - I tried to adapt all doc-strings - hopefully I missed none.